### PR TITLE
PAYLAPMEXT-298: inversion des URLs de redirection & notification

### DIFF
--- a/src/main/java/com/payline/payment/ppewshop/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/payline/payment/ppewshop/service/impl/PaymentServiceImpl.java
@@ -99,8 +99,8 @@ public class PaymentServiceImpl implements PaymentService {
                 .build();
 
         MerchantConfiguration merchantConfiguration = MerchantConfiguration.Builder.aMerchantConfiguration()
-                .withGuardBackUrl(request.getEnvironment().getNotificationURL())
-                .withGuardPushUrl(request.getEnvironment().getRedirectionReturnURL())
+                .withGuardBackUrl(request.getEnvironment().getRedirectionReturnURL())
+                .withGuardPushUrl(request.getEnvironment().getNotificationURL())
                 .build();
 
         Buyer buyer = request.getBuyer();

--- a/src/test/java/com/payline/payment/ppewshop/MockUtils.java
+++ b/src/test/java/com/payline/payment/ppewshop/MockUtils.java
@@ -22,6 +22,8 @@ import org.mockito.internal.util.reflection.FieldSetter;
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.mockito.Mockito.doReturn;
@@ -177,13 +179,18 @@ public class MockUtils {
      * Generate a valid {@link Buyer}.
      */
     public static Buyer aBuyer() {
-        return Buyer.BuyerBuilder.aBuyer()
-                .withFullName(new Buyer.FullName("Marie", "Durand", "1"))
-                .withBirthday(new Date())
-                .withAddresses(addresses())
-                .withPhoneNumbers(phoneNumbers())
-                .withEmail("foo@bar.baz")
-                .build();
+        try {
+            return Buyer.BuyerBuilder.aBuyer()
+                    .withFullName(new Buyer.FullName("Marie", "Durand", "1"))
+                    .withBirthday(new SimpleDateFormat("dd-MM-yyyy").parse("01-01-2020"))
+                    .withAddresses(addresses())
+                    .withPhoneNumbers(phoneNumbers())
+                    .withEmail("foo@bar.baz")
+                    .build();
+        } catch (ParseException e) {
+            // should never append
+            return null;
+        }
     }
 
     public static Map<Buyer.AddressType, Buyer.Address> addresses() {
@@ -267,7 +274,7 @@ public class MockUtils {
                 .withCaptureNow(true)
                 .withContractConfiguration(aContractConfiguration())
                 .withEnvironment(anEnvironment())
-                .withLocale(Locale.getDefault())
+                .withLocale(Locale.FRANCE)
                 .withOrder(aPaylineOrder())
                 .withPartnerConfiguration(aPartnerConfiguration())
                 .withPaymentFormContext(aPaymentFormContext())

--- a/src/test/java/com/payline/payment/ppewshop/service/impl/PaymentServiceImplTest.java
+++ b/src/test/java/com/payline/payment/ppewshop/service/impl/PaymentServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.payline.payment.ppewshop.service.impl;
 
 import com.payline.payment.ppewshop.MockUtils;
+import com.payline.payment.ppewshop.bean.common.*;
 import com.payline.payment.ppewshop.bean.request.InitDossierRequest;
 import com.payline.payment.ppewshop.bean.response.InitDossierResponse;
 import com.payline.payment.ppewshop.bean.response.PpewShopResponseKO;
@@ -43,7 +44,7 @@ class PaymentServiceImplTest {
     }
 
     @Test
-    void paymentRequest(){
+    void paymentRequest() {
         // init Mock
         InitDossierResponse initDossierResponse = InitDossierResponse.fromXml(MockUtils.templateInitDossierResponse);
         Mockito.doReturn(initDossierResponse).when(httpService).initDossier(Mockito.any(), Mockito.any());
@@ -90,13 +91,44 @@ class PaymentServiceImplTest {
         InitDossierRequest initDossierRequest = service.createInitDossierFromPaymentRequest(request);
 
         Assertions.assertNotNull(initDossierRequest);
-        Assertions.assertNotNull(initDossierRequest.getInitDossierIn());
-        Assertions.assertNotNull(initDossierRequest.getInitDossierIn().getCustomerInformation());
-        Assertions.assertNotNull(initDossierRequest.getInitDossierIn().getMerchantConfiguration());
-        Assertions.assertNotNull(initDossierRequest.getInitDossierIn().getMerchantInformation());
-        Assertions.assertNotNull(initDossierRequest.getInitDossierIn().getOrderInformation());
-        Assertions.assertNotNull(initDossierRequest.getInitDossierIn().getOrderReference());
-        
+        InitDossierIn dossierIn = initDossierRequest.getInitDossierIn();
+        Assertions.assertNotNull(dossierIn);
+
+        CustomerInformation customerInformation = dossierIn.getCustomerInformation();
+        Assertions.assertNotNull(customerInformation);
+        Assertions.assertEquals("street1", customerInformation.getAddressLine1());
+        Assertions.assertEquals("street2", customerInformation.getAddressLine2());
+        Assertions.assertEquals("01-01-2020", customerInformation.getBirthDate());
+        Assertions.assertEquals("0612345678", customerInformation.getCellPhoneNumber());
+        Assertions.assertEquals("City", customerInformation.getCity());
+        Assertions.assertEquals("FRA", customerInformation.getCustomerLanguage());
+        Assertions.assertEquals("foo@bar.baz", customerInformation.getEmail());
+        Assertions.assertEquals("Marie", customerInformation.getFirstName());
+        Assertions.assertEquals("Durand", customerInformation.getName());
+        Assertions.assertEquals("75000", customerInformation.getPostCode());
+        Assertions.assertEquals("0612345678", customerInformation.getPrivatePhoneNumber());
+        Assertions.assertEquals("0712345678", customerInformation.getProfessionalPhoneNumber());
+
+        MerchantConfiguration merchantConfiguration = dossierIn.getMerchantConfiguration();
+        Assertions.assertNotNull(merchantConfiguration);
+        Assertions.assertEquals("http://redirectionURL.com", merchantConfiguration.getGuarBackUrl());
+        Assertions.assertEquals("http://notificationURL.com", merchantConfiguration.getGuarPushUrl());
+
+        MerchantInformation merchantInformation = dossierIn.getMerchantInformation();
+        Assertions.assertNotNull(merchantInformation);
+        Assertions.assertEquals("FRA", merchantInformation.getCountryCode());
+        Assertions.assertEquals("1000828996", merchantInformation.getDistributorNumber());
+        Assertions.assertEquals("3550937738", merchantInformation.getMerchantCode());
+
+        OrderInformation orderInformation = dossierIn.getOrderInformation();
+        Assertions.assertNotNull(orderInformation);
+        Assertions.assertEquals("CLA", orderInformation.getFinancialProductType());
+        Assertions.assertEquals("625", orderInformation.getGoodsCode());
+        Assertions.assertEquals("2000.00", orderInformation.getPrice());
+
+        MerchantOrderReference orderReference = dossierIn.getOrderReference();
+        Assertions.assertNotNull(orderReference);
+        Assertions.assertEquals("1234567890123", orderReference.getMerchantOrderId());
     }
 
     @Test


### PR DESCRIPTION
Les configs ne changent pas.
![image](https://user-images.githubusercontent.com/41673610/97973125-e6085280-1dc5-11eb-8861-7126b1346da1.png)

certains codesmells sont corrigé dans la livraison du ticket 295